### PR TITLE
feat: improve SEO metadata across storefront

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -12,9 +12,13 @@ useSeoMeta({
   description: siteDescription,
   ogType: 'website',
   ogImage: 'https://commerce.nuxt.dev/social-card.jpg',
+  ogSiteName: siteName,
+  ogLocale: 'en_US',
   twitterCard: 'summary_large_image',
   twitterSite: '@zhatlen',
   twitterCreator: '@zhatlen',
+  twitterImage: 'https://commerce.nuxt.dev/social-card.jpg',
+  keywords: `${siteName}, ecommerce, nuxt, woocommerce`,
   viewport: 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, viewport-fit=cover',
 });
 </script>

--- a/app/pages/categories.vue
+++ b/app/pages/categories.vue
@@ -11,6 +11,11 @@ useSeoMeta({
   ogDescription: `Browse product categories on ${siteName}.`,
   ogUrl: canonical,
   canonical,
+  keywords: `categories, ${siteName}`,
+  twitterTitle: 'Categories',
+  twitterDescription: `Browse product categories on ${siteName}.`,
+  ogImage: 'https://commerce.nuxt.dev/social-card.jpg',
+  twitterImage: 'https://commerce.nuxt.dev/social-card.jpg',
 });
 
 onMounted(() => {

--- a/app/pages/favorites.vue
+++ b/app/pages/favorites.vue
@@ -11,6 +11,12 @@ useSeoMeta({
   ogDescription: `Your favorite products saved on ${siteName}.`,
   ogUrl: canonical,
   canonical,
+  keywords: `favorites, wishlist, ${siteName}`,
+  twitterTitle: 'Favorites',
+  twitterDescription: `Your favorite products saved on ${siteName}.`,
+  ogImage: 'https://commerce.nuxt.dev/social-card.jpg',
+  twitterImage: 'https://commerce.nuxt.dev/social-card.jpg',
+  robots: 'noindex, nofollow',
 });
 </script>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,15 +2,50 @@
 const route = useRoute();
 const { siteName } = useAppConfig();
 const url = useRequestURL();
-const canonical = url.origin + url.pathname;
+const canonical = computed(() => {
+  const base = `${url.origin}${url.pathname}`;
+  const params = new URLSearchParams();
+  if (typeof route.query.q === 'string' && route.query.q) params.set('q', route.query.q);
+  if (typeof route.query.category === 'string' && route.query.category) params.set('category', route.query.category);
+  const query = params.toString();
+  return query ? `${base}?${query}` : base;
+});
 
-useSeoMeta({
-  title: 'Home',
-  ogTitle: 'Home',
-  description: `Discover the latest products on ${siteName}.`,
-  ogDescription: `Discover the latest products on ${siteName}.`,
-  ogUrl: canonical,
-  canonical,
+useSeoMeta(() => {
+  const q = typeof route.query.q === 'string' ? route.query.q : undefined;
+  const category = typeof route.query.category === 'string' ? route.query.category : undefined;
+
+  let title = 'Home';
+  let description = `Discover the latest products on ${siteName}.`;
+  const keywords = new Set(['ecommerce', siteName]);
+
+  if (category) {
+    title = `${category} Products`;
+    description = `Browse ${category} products on ${siteName}.`;
+    keywords.add(category);
+  }
+
+  if (q) {
+    title = `Search results for "${q}"`;
+    description = `Search results for "${q}" on ${siteName}.`;
+    keywords.add(q);
+  }
+
+  const canonicalUrl = canonical.value;
+
+  return {
+    title,
+    ogTitle: title,
+    description,
+    ogDescription: description,
+    ogUrl: canonicalUrl,
+    canonical: canonicalUrl,
+    keywords: Array.from(keywords).join(', '),
+    twitterTitle: title,
+    twitterDescription: description,
+    ogImage: 'https://commerce.nuxt.dev/social-card.jpg',
+    twitterImage: 'https://commerce.nuxt.dev/social-card.jpg',
+  };
 });
 
 const productsData = ref([]);

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -11,12 +11,12 @@ const canonical = computed(() => {
   return query ? `${base}?${query}` : base;
 });
 
-useSeoMeta(() => {
+useHead(() => {
   const q = typeof route.query.q === 'string' ? route.query.q : undefined;
   const category = typeof route.query.category === 'string' ? route.query.category : undefined;
 
-  let title = 'Home';
-  let description = `Discover the latest products on ${siteName}.`;
+  let title = '';
+  let description = '';
   const keywords = new Set(['ecommerce', siteName]);
 
   if (category) {

--- a/app/pages/product/[id].vue
+++ b/app/pages/product/[id].vue
@@ -65,13 +65,11 @@ const plainDescription = computed(() => {
   return raw ? raw.slice(0, 160) : '';
 });
 
-useSeoMeta(() => {
+useHead(() => {
   const title = product.value?.name || siteName;
   const description = plainDescription.value;
   const img = image.value;
-  const keywords = [product.value?.name, product.value?.allPaStyle?.nodes?.[0]?.name, siteName]
-    .filter(Boolean)
-    .join(', ');
+  const keywords = [product.value?.name, product.value?.allPaStyle?.nodes?.[0]?.name, siteName].filter(Boolean).join(', ');
 
   return {
     title,

--- a/app/pages/product/[id].vue
+++ b/app/pages/product/[id].vue
@@ -56,22 +56,56 @@ const calculateDiscountPercentage = computed(() => {
   return Math.round(((salePriceValue - regularPriceValue) / regularPriceValue) * 100);
 });
 
+const { siteName } = useAppConfig();
 const url = useRequestURL();
 const canonical = url.origin + url.pathname;
+const image = computed(() => product.value?.image?.sourceUrl);
 const plainDescription = computed(() => {
   const raw = product.value?.description?.replace(/<[^>]+>/g, '');
   return raw ? raw.slice(0, 160) : '';
 });
 
-useHead(() => ({
-  title: product.value?.name,
-  ogTitle: product.value?.name,
+useSeoMeta(() => {
+  const title = product.value?.name || siteName;
+  const description = plainDescription.value;
+  const img = image.value;
+  const keywords = [product.value?.name, product.value?.allPaStyle?.nodes?.[0]?.name, siteName]
+    .filter(Boolean)
+    .join(', ');
+
+  return {
+    title,
+    ogTitle: title,
+    description,
+    ogDescription: description,
+    ogImage: img,
+    ogUrl: canonical,
+    canonical,
+    ogType: 'product',
+    twitterTitle: title,
+    twitterDescription: description,
+    twitterImage: img,
+    keywords,
+  };
+});
+
+const productSchema = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'Product',
+  name: product.value?.name,
   description: plainDescription.value,
-  ogDescription: plainDescription.value,
-  ogImage: product.value?.image?.sourceUrl,
-  ogUrl: canonical,
-  canonical,
-  twitterCard: 'summary_large_image',
+  image: image.value ? [image.value] : [],
+  sku: product.value?.sku,
+  brand: { '@type': 'Brand', name: siteName },
+}));
+
+useHead(() => ({
+  script: [
+    {
+      type: 'application/ld+json',
+      children: JSON.stringify(productSchema.value),
+    },
+  ],
 }));
 
 const { handleAddToCart, addToCartButtonStatus } = useCart();


### PR DESCRIPTION
## Summary
- add global Open Graph and Twitter defaults
- generate query-aware titles, descriptions, and canonicals for listings
- enhance page SEO with keywords, robots rules, and product JSON-LD

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bd908d9a608333b64213cd5cd1fdf4