### PR TITLE
Handle GraphQL errors in WP utility

### DIFF
--- a/server/utils/wpgraphql.ts
+++ b/server/utils/wpgraphql.ts
@@ -1,5 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
-import { getCookie, setCookie } from 'h3';
+import { getCookie, setCookie, createError } from 'h3';
 
 let client: GraphQLClient;
 
@@ -10,22 +10,36 @@ function getClient() {
   return client;
 }
 
-export function requestQuery(query: string, variables: any = {}) {
-  return getClient().request(query, variables);
+export async function requestQuery(query: string, variables: any = {}) {
+  try {
+    return await getClient().request(query, variables);
+  } catch (error: any) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: error?.message || 'GraphQL query request failed',
+    });
+  }
 }
 
 export async function requestMutation(event: any, query: string, variables: any = {}) {
   const session = getCookie(event, 'woocommerce-session');
   const client = getClient();
 
-  if (!session) {
-    const res = await client.rawRequest(query, variables);
-    const newSession = res.headers.get('woocommerce-session');
-    if (newSession) {
-      setCookie(event, 'woocommerce-session', `Session ${newSession}`, { path: '/' });
+  try {
+    if (!session) {
+      const res = await client.rawRequest(query, variables);
+      const newSession = res.headers.get('woocommerce-session');
+      if (newSession) {
+        setCookie(event, 'woocommerce-session', `Session ${newSession}`, { path: '/' });
+      }
+      return res.data;
     }
-    return res.data;
-  }
 
-  return await client.request(query, variables, { 'woocommerce-session': session });
+    return await client.request(query, variables, { 'woocommerce-session': session });
+  } catch (error: any) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: error?.message || 'GraphQL mutation request failed',
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- wrap wpgraphql query and mutation requests in try/catch
- surface GraphQL errors via h3 `createError` with HTTP 500

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68bd97292e908333a4e0197274a03ff1