### PR TITLE
feat: persist wishlist across components

### DIFF
--- a/app/composables/useWishlist.js
+++ b/app/composables/useWishlist.js
@@ -1,7 +1,9 @@
 export const useWishlist = product => {
-  const wishlist = ref([]);
+  const wishlist = useState('wishlist', () => []);
 
-  const isWishlisted = computed(() => wishlist.value.some(item => item.databaseId === product.databaseId));
+  const isWishlisted = computed(() =>
+    product ? wishlist.value.some(item => item.databaseId === product.databaseId) : false
+  );
 
   const updateLocalStorage = () => {
     localStorage.setItem('wishlist', JSON.stringify(wishlist.value));
@@ -9,7 +11,9 @@ export const useWishlist = product => {
 
   const toggleWishlist = item => {
     if (isWishlisted.value) {
-      wishlist.value = wishlist.value.filter(existingItem => existingItem.databaseId !== product.databaseId);
+      wishlist.value = wishlist.value.filter(
+        existingItem => existingItem.databaseId !== item.databaseId
+      );
     } else {
       wishlist.value.push(item);
     }


### PR DESCRIPTION
## Summary
- share wishlist state across components using `useState`
- guard `isWishlisted` computation and update toggler logic

## Testing
- `npm test` (fails: Missing script "test")
- `pnpm build` (fails: Nuxt Build Error: [vite:define] The service was stopped: write EPIPE)


------
https://chatgpt.com/codex/tasks/task_e_68bd9728b5188333a367300e20b16bd8