### PR TITLE
feat: centralize GraphQL data fetching

### DIFF
--- a/app/composables/useGraphql.js
+++ b/app/composables/useGraphql.js
@@ -1,0 +1,10 @@
+import { unref } from 'vue';
+
+export function useGraphql(key, query, variables = {}) {
+  return useAsyncData(key, () =>
+    $fetch('/api/graphql', {
+      method: 'POST',
+      body: { query, variables: unref(variables) },
+    })
+  );
+}

--- a/app/pages/categories.vue
+++ b/app/pages/categories.vue
@@ -1,5 +1,6 @@
 <script setup>
-const categoriesData = ref([]);
+import { getCategoriesQuery } from '~/gql/queries/getCategories';
+
 const { siteName } = useAppConfig();
 const url = useRequestURL();
 const canonical = url.origin + url.pathname;
@@ -18,15 +19,13 @@ useSeoMeta({
   twitterImage: 'https://commerce.nuxt.dev/social-card.jpg',
 });
 
-onMounted(() => {
-  $fetch('/api/categories').then(response => (
-    (categoriesData.value = response.productCategories.nodes.filter(
-      category => category.products.nodes.length && category.children.nodes.length
-    ))
-  ));
-});
+const { data: categoriesData } = await useGraphql('categories', getCategoriesQuery);
 
-const categories = computed(() => categoriesData.value);
+const categories = computed(() =>
+  (categoriesData.value?.productCategories?.nodes || []).filter(
+    category => category.products.nodes.length && category.children.nodes.length
+  )
+);
 </script>
 
 <template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { getProductsQuery } from '~/gql/queries/getProducts';
 const route = useRoute();
 const { siteName } = useAppConfig();
 const url = useRequestURL();
@@ -67,11 +68,13 @@ async function fetch() {
   isLoading.value = true;
 
   try {
-    const response = await $fetch('/api/products', {
-      query: variables.value,
-    });
-    productsData.value.push(...response.products.nodes);
-    pageInfo.value = response.products.pageInfo;
+    const { data } = await useGraphql(
+      `products-${pageInfo.value.endCursor || 'start'}`,
+      getProductsQuery,
+      variables.value
+    );
+    productsData.value.push(...data.value.products.nodes);
+    pageInfo.value = data.value.products.pageInfo;
     hasFetched.value = true;
   } finally {
     isLoading.value = false;

--- a/app/pages/product/[id].vue
+++ b/app/pages/product/[id].vue
@@ -1,11 +1,11 @@
 <script setup>
 import { Swiper, SwiperSlide } from 'swiper/vue';
 import { Navigation, Pagination, Thumbs } from 'swiper/modules';
-const { isOpenImageSliderModal } = useComponents();
-
+import { getProductQuery } from '~/gql/queries/getProduct';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
+const { isOpenImageSliderModal } = useComponents();
 
 const thumbsSwiper = ref(null);
 const setThumbsSwiper = swiper => {
@@ -20,16 +20,10 @@ const parts = id.value.split('-');
 const sku = parts.pop();
 const slug = parts.join('-');
 
-const productResult = ref({});
+const { data: productResult } = await useGraphql('product', getProductQuery, { slug, sku });
 const selectedVariation = ref(null);
 
-onMounted(() => {
-  $fetch('/api/product', {
-    query: { slug, sku },
-  }).then(data => (productResult.value = data.product));
-});
-
-const product = computed(() => productResult.value);
+const product = computed(() => productResult.value?.product || {});
 
 const sizeOrder = ['xxs', 'xs', 's', 'm', 'l', 'xl', '2xl', '23-24', '25', '26-27', '28-29', '30', '31-32', '33', '34-25'];
 

--- a/server/api/graphql.post.ts
+++ b/server/api/graphql.post.ts
@@ -1,0 +1,7 @@
+import { readBody } from 'h3';
+import { requestQuery } from '~~/server/utils/wpgraphql';
+
+export default defineEventHandler(async (event) => {
+  const { query, variables } = await readBody(event);
+  return await requestQuery(query, variables);
+});


### PR DESCRIPTION
## Summary
- add a generic `/api/graphql` endpoint
- introduce `useGraphql` composable using `useAsyncData`
- refactor pages to fetch data through the new composable

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68bd9564f53c83338e5144111d291129