### PR TITLE
feat: cache static pages and API handlers

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,9 @@ import pkg from './package.json';
 export default defineNuxtConfig({
   devtools: { enabled: false },
   modules: ['nuxt-graphql-request', '@vueuse/nuxt', '@nuxt/ui', '@nuxt/image', 'notivue/nuxt', '@nuxthub/core'],
+  hub: {
+    cache: true,
+  },
   notivue: {
     position: 'top-center',
     limit: 3,
@@ -30,6 +33,12 @@ export default defineNuxtConfig({
     prerender: {
       routes: ['/sitemap.xml', '/robots.txt'],
     },
+  },
+  routeRules: {
+    '/': { cache: { maxAge: 60 * 60 } },
+    '/categories': { cache: { maxAge: 60 * 60 } },
+    '/favorites': { cache: { maxAge: 60 * 60 } },
+    '/product/**': { cache: { maxAge: 60 * 60 } },
   },
   compatibilityDate: '2024-08-03',
 });

--- a/server/api/categories.get.ts
+++ b/server/api/categories.get.ts
@@ -1,8 +1,10 @@
 import { getCategoriesQuery } from '~/gql/queries/getCategories';
 import { requestQuery } from '~~/server/utils/wpgraphql';
 
-export default defineCachedEventHandler(async () => {
-  return await requestQuery(getCategoriesQuery);
+export default cachedEventHandler(async event => {
+  return await requestQuery(event, getCategoriesQuery);
 }, {
+  name: 'api-categories',
   maxAge: 60 * 60,
+  getKey: event => event.path,
 });

--- a/server/api/product.get.ts
+++ b/server/api/product.get.ts
@@ -2,10 +2,11 @@ import { getQuery } from 'h3';
 import { getProductQuery } from '~/gql/queries/getProduct';
 import { requestQuery } from '~~/server/utils/wpgraphql';
 
-export default defineCachedEventHandler(async event => {
+export default cachedEventHandler(async event => {
   const { slug, sku } = getQuery(event);
-  return await requestQuery(getProductQuery, { slug, sku });
+  return await requestQuery(event, getProductQuery, { slug, sku });
 }, {
+  name: 'api-product',
   maxAge: 60 * 5,
   getKey: event => event.req.url!,
 });

--- a/server/api/products.get.ts
+++ b/server/api/products.get.ts
@@ -2,11 +2,12 @@ import { getQuery } from 'h3';
 import { getProductsQuery } from '~/gql/queries/getProducts';
 import { requestQuery } from '~~/server/utils/wpgraphql';
 
-export default defineCachedEventHandler(async event => {
+export default cachedEventHandler(async event => {
   const { after, search, category, order = 'DESC', field = 'DATE' } = getQuery(event);
   const variables = { after, search, category, order, field };
-  return await requestQuery(getProductsQuery, variables);
+  return await requestQuery(event, getProductsQuery, variables);
 }, {
+  name: 'api-products',
   maxAge: 60,
   getKey: event => event.req.url!,
 });

--- a/server/api/search.get.ts
+++ b/server/api/search.get.ts
@@ -2,10 +2,11 @@ import { getQuery } from 'h3';
 import { getSearchProductsQuery } from '~/gql/queries/getSearchProducts';
 import { requestQuery } from '~~/server/utils/wpgraphql';
 
-export default defineCachedEventHandler(async event => {
+export default cachedEventHandler(async event => {
   const { search = '' } = getQuery(event);
-  return await requestQuery(getSearchProductsQuery, { search });
+  return await requestQuery(event, getSearchProductsQuery, { search });
 }, {
+  name: 'api-search',
   maxAge: 60,
   getKey: event => event.req.url!,
 });

--- a/server/routes/robots.txt.ts
+++ b/server/routes/robots.txt.ts
@@ -1,8 +1,15 @@
 import { getRequestURL, setHeader } from 'h3';
 
-export default defineEventHandler(event => {
-  setHeader(event, 'Content-Type', 'text/plain');
-  const url = getRequestURL(event);
-  return `User-agent: *\nAllow: /\nSitemap: ${url.origin}/sitemap.xml`;
-});
+export default cachedEventHandler(
+  event => {
+    setHeader(event, 'Content-Type', 'text/plain');
+    const url = getRequestURL(event);
+    return `User-agent: *\nAllow: /\nSitemap: ${url.origin}/sitemap.xml`;
+  },
+  {
+    name: 'robots-txt',
+    maxAge: 60 * 60,
+    getKey: event => event.path,
+  },
+);
 

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -1,16 +1,23 @@
 import { getRequestURL, setHeader } from 'h3';
 
-export default defineEventHandler(event => {
-  setHeader(event, 'Content-Type', 'application/xml');
-  const url = getRequestURL(event);
-  const base = url.origin;
-  const routes = ['/', '/categories', '/favorites'];
+export default cachedEventHandler(
+  event => {
+    setHeader(event, 'Content-Type', 'application/xml');
+    const url = getRequestURL(event);
+    const base = url.origin;
+    const routes = ['/', '/categories', '/favorites'];
 
-  return (
-    `<?xml version="1.0" encoding="UTF-8"?>\n` +
-    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-    routes.map(route => `  <url><loc>${base}${route}</loc></url>`).join('\n') +
-    `\n</urlset>`
-  );
-});
+    return (
+      `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+      routes.map(route => `  <url><loc>${base}${route}</loc></url>`).join('\n') +
+      `\n</urlset>`
+    );
+  },
+  {
+    name: 'sitemap-xml',
+    maxAge: 60 * 60,
+    getKey: event => event.path,
+  },
+);
 

--- a/server/utils/wpgraphql.ts
+++ b/server/utils/wpgraphql.ts
@@ -1,5 +1,6 @@
 import { GraphQLClient } from 'graphql-request';
 import { getCookie, setCookie, createError } from 'h3';
+import type { H3Event } from 'h3';
 
 let client: GraphQLClient;
 
@@ -10,7 +11,7 @@ function getClient() {
   return client;
 }
 
-export async function requestQuery(query: string, variables: any = {}) {
+export const requestQuery = defineCachedFunction(async (event: H3Event, query: string, variables: any = {}) => {
   try {
     return await getClient().request(query, variables);
   } catch (error: any) {
@@ -19,7 +20,11 @@ export async function requestQuery(query: string, variables: any = {}) {
       statusMessage: error?.message || 'GraphQL query request failed',
     });
   }
-}
+}, {
+  name: 'wp-queries',
+  maxAge: 60 * 60,
+  getKey: (_event, query, variables) => query + JSON.stringify(variables),
+});
 
 export async function requestMutation(event: any, query: string, variables: any = {}) {
   const session = getCookie(event, 'woocommerce-session');


### PR DESCRIPTION
## Summary
- enable cache storage via NuxtHub config
- cache API, robots and sitemap handlers with event-based keys
- memoize GraphQL queries with a cached server function

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bf0829868083339b2f57b45c472fdf