### PR TITLE
feat: enable NuxtHub caching

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,26 @@ import pkg from './package.json';
 export default defineNuxtConfig({
   devtools: { enabled: false },
   modules: ['nuxt-graphql-request', '@vueuse/nuxt', '@nuxt/ui', '@nuxt/image', 'notivue/nuxt', '@nuxthub/core'],
+  hub: {
+    cache: true,
+  },
+  routeRules: {
+    '/': {
+      cache: {
+        maxAge: 60,
+      },
+    },
+    '/categories': {
+      cache: {
+        maxAge: 60 * 60,
+      },
+    },
+    '/product/**': {
+      cache: {
+        maxAge: 60 * 5,
+      },
+    },
+  },
   notivue: {
     position: 'top-center',
     limit: 3,

--- a/server/api/categories.get.ts
+++ b/server/api/categories.get.ts
@@ -5,4 +5,6 @@ export default defineCachedEventHandler(async () => {
   return await requestQuery(getCategoriesQuery);
 }, {
   maxAge: 60 * 60,
+  name: 'categories',
+  getKey: () => 'all',
 });

--- a/server/api/product.get.ts
+++ b/server/api/product.get.ts
@@ -1,11 +1,7 @@
 import { getQuery } from 'h3';
-import { getProductQuery } from '~/gql/queries/getProduct';
-import { requestQuery } from '~~/server/utils/wpgraphql';
+import { getProductCached } from '~~/server/utils/product';
 
-export default defineCachedEventHandler(async event => {
+export default defineEventHandler(async event => {
   const { slug, sku } = getQuery(event);
-  return await requestQuery(getProductQuery, { slug, sku });
-}, {
-  maxAge: 60 * 5,
-  getKey: event => event.req.url!,
+  return await getProductCached(event, slug as string | undefined, sku as string | undefined);
 });

--- a/server/api/products.get.ts
+++ b/server/api/products.get.ts
@@ -8,5 +8,6 @@ export default defineCachedEventHandler(async event => {
   return await requestQuery(getProductsQuery, variables);
 }, {
   maxAge: 60,
+  name: 'products',
   getKey: event => event.req.url!,
 });

--- a/server/api/search.get.ts
+++ b/server/api/search.get.ts
@@ -7,5 +7,6 @@ export default defineCachedEventHandler(async event => {
   return await requestQuery(getSearchProductsQuery, { search });
 }, {
   maxAge: 60,
+  name: 'search',
   getKey: event => event.req.url!,
 });

--- a/server/routes/robots.txt.ts
+++ b/server/routes/robots.txt.ts
@@ -1,8 +1,12 @@
 import { getRequestURL, setHeader } from 'h3';
 
-export default defineEventHandler(event => {
+export default defineCachedEventHandler(event => {
   setHeader(event, 'Content-Type', 'text/plain');
   const url = getRequestURL(event);
   return `User-agent: *\nAllow: /\nSitemap: ${url.origin}/sitemap.xml`;
+}, {
+  maxAge: 60 * 60,
+  name: 'robots',
+  getKey: () => 'robots',
 });
 

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -1,6 +1,6 @@
 import { getRequestURL, setHeader } from 'h3';
 
-export default defineEventHandler(event => {
+export default defineCachedEventHandler(event => {
   setHeader(event, 'Content-Type', 'application/xml');
   const url = getRequestURL(event);
   const base = url.origin;
@@ -12,5 +12,9 @@ export default defineEventHandler(event => {
     routes.map(route => `  <url><loc>${base}${route}</loc></url>`).join('\n') +
     `\n</urlset>`
   );
+}, {
+  maxAge: 60 * 60,
+  name: 'sitemap',
+  getKey: () => 'sitemap',
 });
 

--- a/server/utils/product.ts
+++ b/server/utils/product.ts
@@ -1,0 +1,11 @@
+import type { H3Event } from 'h3'
+import { getProductQuery } from '~/gql/queries/getProduct'
+import { requestQuery } from '~~/server/utils/wpgraphql'
+
+export const getProductCached = defineCachedFunction(async (_event: H3Event, slug?: string, sku?: string) => {
+  return await requestQuery(getProductQuery, { slug, sku })
+}, {
+  maxAge: 60 * 5,
+  name: 'product',
+  getKey: (_event: H3Event, slug?: string, sku?: string) => slug || sku || 'default',
+})


### PR DESCRIPTION
## Summary
- configure NuxtHub cache and route-level caching rules
- cache product lookups with defineCachedFunction and reuse in API route
- cache sitemap and robots routes via `defineCachedEventHandler`

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68c07fe18d048333b35474673d3e6e61