### PR TITLE
fix: Introduce ProductPrice component for consistent price display across views

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -180,10 +180,7 @@ const totalQuantity = computed(() => cart.value.reduce((s, i) => s + (i.quantity
                   class="absolute h-full w-full dark:bg-neutral-800 bg-neutral-200 object-cover transition-opacity duration-300 group-hover:opacity-0" />
               </div>
               <div class="grid gap-0.5 pt-3 pb-4 px-1.5 text-sm font-semibold">
-                <ProductPrice
-                    :sale-price="product.salePrice"
-                    :regular-price="product.regularPrice"
-                    variant="card" />
+                <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" variant="card" />
                 <div>{{ product.name }}</div>
                 <div class="font-normal text-[#5f5f5f] dark:text-[#a3a3a3]">
                   {{ product.allPaStyle?.nodes[0]?.name }}

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -183,7 +183,7 @@ const totalQuantity = computed(() => cart.value.reduce((s, i) => s + (i.quantity
                 <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" variant="card" />
                 <div>{{ product.name }}</div>
                 <div class="font-normal text-[#5f5f5f] dark:text-[#a3a3a3]">
-                  {{ product.allPaStyle?.nodes[0]?.name }}
+                  {{ product.allPaStyle.nodes[0].name }}
                 </div>
               </div>
             </div>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -180,13 +180,13 @@ const totalQuantity = computed(() => cart.value.reduce((s, i) => s + (i.quantity
                   class="absolute h-full w-full dark:bg-neutral-800 bg-neutral-200 object-cover transition-opacity duration-300 group-hover:opacity-0" />
               </div>
               <div class="grid gap-0.5 pt-3 pb-4 px-1.5 text-sm font-semibold">
-                <div class="flex gap-1">
-                  <div v-html="product.salePrice"></div>
-                  <div class="text-[#5f5f5f] dark:text-[#a3a3a3] line-through" v-html="product.regularPrice"></div>
-                </div>
+                <ProductPrice
+                    :sale-price="product.salePrice"
+                    :regular-price="product.regularPrice"
+                    variant="card" />
                 <div>{{ product.name }}</div>
                 <div class="font-normal text-[#5f5f5f] dark:text-[#a3a3a3]">
-                  {{ product.allPaStyle.nodes[0].name }}
+                  {{ product.allPaStyle?.nodes[0]?.name }}
                 </div>
               </div>
             </div>

--- a/app/components/Cart.vue
+++ b/app/components/Cart.vue
@@ -19,12 +19,11 @@ const { order } = useCheckout();
               <NuxtImg :src="product.variation.node.image.sourceUrl" class="w-24 h-28 object-cover shadow-md rounded-2xl" />
               <div class="flex-1 gap-1 flex flex-col">
                 <div class="font-medium text-sm line-clamp-2 overflow-hidden text-ellipsis">{{ product.product.node.name }}</div>
-                <div class="font-bold">${{ (Number(product.variation.node.salePrice) * product.quantity).toFixed(2) }}</div>
-                <div class="flex-wrap text-neutral-600 dark:text-neutral-300 items-baseline text-xs gap-1 flex-row flex">
-                  <p>{{ $t('product.originally') }}:</p>
-                  <p class="line-through">${{ (Number(product.variation.node.regularPrice) * product.quantity).toFixed(2) }}</p>
-                  <p class="text-alizarin-crimson-700">-{{ ((1 - product.variation.node.salePrice / product.variation.node.regularPrice) * 100).toFixed(0) }}%</p>
-                </div>
+                <ProductPrice
+                    :sale-price="product.variation.node.salePrice"
+                    :regular-price="product.variation.node.regularPrice"
+                    :quantity="product.quantity"
+                    variant="cart" />
                 <div class="text-xs flex gap-2 font-medium text-neutral-600 dark:text-neutral-300">
                   <div>
                     {{ $t('product.size') }}: {{ product.variation.attributes.map(attr => attr.value.toUpperCase()).join(', ') }} • {{ $t('product.quantity') }}:

--- a/app/components/Cart.vue
+++ b/app/components/Cart.vue
@@ -19,11 +19,7 @@ const { order } = useCheckout();
               <NuxtImg :src="product.variation.node.image.sourceUrl" class="w-24 h-28 object-cover shadow-md rounded-2xl" />
               <div class="flex-1 gap-1 flex flex-col">
                 <div class="font-medium text-sm line-clamp-2 overflow-hidden text-ellipsis">{{ product.product.node.name }}</div>
-                <ProductPrice
-                    :sale-price="product.variation.node.salePrice"
-                    :regular-price="product.variation.node.regularPrice"
-                    :quantity="product.quantity"
-                    variant="cart" />
+                <ProductPrice :sale-price="product.variation.node.salePrice" :regular-price="product.variation.node.regularPrice" :quantity="product.quantity" variant="cart" />
                 <div class="text-xs flex gap-2 font-medium text-neutral-600 dark:text-neutral-300">
                   <div>
                     {{ $t('product.size') }}: {{ product.variation.attributes.map(attr => attr.value.toUpperCase()).join(', ') }} • {{ $t('product.quantity') }}:

--- a/app/components/Checkout.vue
+++ b/app/components/Checkout.vue
@@ -4,6 +4,20 @@ const { userDetails, checkoutStatus, handleCheckout } = useCheckout();
 const { cart } = useCart();
 
 const totalQuantity = computed(() => cart.value.reduce((s, i) => s + (i.quantity || 0), 0));
+
+const cartTotal = computed(() => {
+  const total = cart.value.reduce((accumulator, item) => {
+    const node = item.variation.node;
+    const regularPrice = parseFloat(node.regularPrice) || 0;
+    const salePrice = parseFloat(node.salePrice) || 0;
+
+    const priceToUse = salePrice > 0 && salePrice < regularPrice ? salePrice : regularPrice;
+
+    return accumulator + priceToUse * (item.quantity ?? 1);
+  }, 0);
+
+  return total.toFixed(2);
+});
 </script>
 
 <template>
@@ -33,7 +47,7 @@ const totalQuantity = computed(() => cart.value.reduce((s, i) => s + (i.quantity
       <div class="text-sm font-semibold p-4 text-neutral-600 dark:text-neutral-400">
         {{
           $t('checkout.pay.description', {
-            total: cart.reduce((total, item) => total + parseFloat(item.variation.node.salePrice) * (item.quantity ?? 1), 0).toFixed(2),
+            total: cartTotal,
             items: totalQuantity,
           })
         }}
@@ -46,7 +60,7 @@ const totalQuantity = computed(() => cart.value.reduce((s, i) => s + (i.quantity
           <div v-if="checkoutStatus === 'order'" class="absolute">
             {{
               $t('checkout.pay.btn', {
-                total: cart.reduce((total, item) => total + parseFloat(item.variation.node.salePrice) * (item.quantity ?? 1), 0).toFixed(2),
+                total: cartTotal,
               })
             }}
           </div>

--- a/app/components/Checkout.vue
+++ b/app/components/Checkout.vue
@@ -10,9 +10,7 @@ const cartTotal = computed(() => {
     const node = item.variation.node;
     const regularPrice = parseFloat(node.regularPrice) || 0;
     const salePrice = parseFloat(node.salePrice) || 0;
-
     const priceToUse = salePrice > 0 && salePrice < regularPrice ? salePrice : regularPrice;
-
     return accumulator + priceToUse * (item.quantity ?? 1);
   }, 0);
 

--- a/app/components/ProductCard.vue
+++ b/app/components/ProductCard.vue
@@ -26,13 +26,13 @@ defineProps({
             class="absolute h-full w-full dark:bg-neutral-800 bg-neutral-200 object-cover transition-opacity duration-300 group-hover:opacity-0" />
         </div>
         <div class="grid gap-0.5 pt-3 pb-4 px-1.5 text-sm font-semibold">
-          <div class="flex gap-1">
-            <div v-html="product.salePrice"></div>
-            <div class="text-[#5f5f5f] dark:text-[#a3a3a3] line-through" v-html="product.regularPrice"></div>
-          </div>
+          <ProductPrice
+              :sale-price="product.salePrice"
+              :regular-price="product.regularPrice"
+              variant="card" />
           <div>{{ product.name }}</div>
           <div class="font-normal text-[#5f5f5f] dark:text-[#a3a3a3]">
-            {{ product.allPaStyle.nodes[0].name }}
+            {{ product.allPaStyle?.nodes[0]?.name }}
           </div>
         </div>
       </div>

--- a/app/components/ProductCard.vue
+++ b/app/components/ProductCard.vue
@@ -26,13 +26,10 @@ defineProps({
             class="absolute h-full w-full dark:bg-neutral-800 bg-neutral-200 object-cover transition-opacity duration-300 group-hover:opacity-0" />
         </div>
         <div class="grid gap-0.5 pt-3 pb-4 px-1.5 text-sm font-semibold">
-          <ProductPrice
-              :sale-price="product.salePrice"
-              :regular-price="product.regularPrice"
-              variant="card" />
+          <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" variant="card" />
           <div>{{ product.name }}</div>
           <div class="font-normal text-[#5f5f5f] dark:text-[#a3a3a3]">
-            {{ product.allPaStyle?.nodes[0]?.name }}
+            {{ product.allPaStyle.nodes[0].name }}
           </div>
         </div>
       </div>

--- a/app/components/ProductPrice.vue
+++ b/app/components/ProductPrice.vue
@@ -57,10 +57,10 @@ const discountPercentage = computed(() => {
       </div>
     </div>
 
-    <div v-else-if="variant === 'card'" class="flex gap-2 text-sm">
+    <div v-else-if="variant === 'card'" class="flex gap-1">
       <template v-if="isSale">
         <span v-html="salePrice"></span>
-        <span class="line-through text-white/50" v-html="regularPrice"></span>
+        <span class="text-[#5f5f5f] dark:text-[#a3a3a3] line-through" v-html="regularPrice"></span>
       </template>
       <template v-else>
         <span v-html="regularPrice"></span>
@@ -68,7 +68,7 @@ const discountPercentage = computed(() => {
     </div>
 
     <div v-else-if="variant === 'cart'">
-      <div v-if="isSale">
+      <div v-if="isSale" class="gap-1 flex flex-col">
         <div class="font-bold">${{ totalSalePrice.toFixed(2) }}</div>
         <div class="flex-wrap text-neutral-600 dark:text-neutral-300 items-baseline text-xs gap-1 flex-row flex">
           <p>{{ $t('product.originally') }}:</p>

--- a/app/components/ProductPrice.vue
+++ b/app/components/ProductPrice.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import {computed} from 'vue';
-
 type PriceVariant = 'default' | 'card' | 'cart';
 
 interface Props {
   salePrice: string;
   regularPrice: string;
   variant?: PriceVariant;
-  quantity?: number; // Add the optional quantity prop
+  quantity?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/app/components/ProductPrice.vue
+++ b/app/components/ProductPrice.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import {computed} from 'vue';
+
+type PriceVariant = 'default' | 'card' | 'cart';
+
+interface Props {
+  salePrice: string;
+  regularPrice: string;
+  variant?: PriceVariant;
+  quantity?: number; // Add the optional quantity prop
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'default',
+  quantity: 1,
+});
+
+const parsePrice = (priceString: string | undefined): number => {
+  if (!priceString) return 0;
+  return parseFloat(String(priceString).replace(/[^0-9.]/g, ''));
+};
+
+const totalSalePrice = computed(() => parsePrice(props.salePrice) * props.quantity);
+const totalRegularPrice = computed(() => parsePrice(props.regularPrice) * props.quantity);
+
+const isSale = computed(() => {
+  const sale = parsePrice(props.salePrice);
+  const regular = parsePrice(props.regularPrice);
+  return sale > 0 && regular > 0 && sale < regular;
+});
+
+const discountPercentage = computed(() => {
+  if (!isSale.value) return 0;
+  const sale = parsePrice(props.salePrice);
+  const regular = parsePrice(props.regularPrice);
+  return Math.round(((regular - sale) / regular) * 100);
+});
+</script>
+
+<template>
+  <div>
+    <div v-if="variant === 'default'">
+      <div v-if="isSale">
+        <div class="flex items-baseline">
+          <p class="text-xl font-bold text-alizarin-crimson-700" v-html="salePrice"></p>
+          <p class="text-sm ml-2">{{ $t('product.vat_included') }}</p>
+        </div>
+        <div class="flex items-baseline">
+          <p class="text-sm">{{ $t('product.originally') }}:</p>
+          <p class="text-sm ml-1 line-through" v-html="regularPrice"></p>
+          <p class="text-sm ml-1 text-alizarin-crimson-700">-{{ discountPercentage }}%</p>
+        </div>
+      </div>
+      <div v-else>
+        <div class="flex items-baseline">
+          <p class="text-xl font-bold" v-html="regularPrice"></p>
+          <p class="text-sm ml-2">{{ $t('product.vat_included') }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="variant === 'card'" class="flex gap-2 text-sm">
+      <template v-if="isSale">
+        <span v-html="salePrice"></span>
+        <span class="line-through text-white/50" v-html="regularPrice"></span>
+      </template>
+      <template v-else>
+        <span v-html="regularPrice"></span>
+      </template>
+    </div>
+
+    <div v-else-if="variant === 'cart'">
+      <div v-if="isSale">
+        <div class="font-bold">${{ totalSalePrice.toFixed(2) }}</div>
+        <div class="flex-wrap text-neutral-600 dark:text-neutral-300 items-baseline text-xs gap-1 flex-row flex">
+          <p>{{ $t('product.originally') }}:</p>
+          <p class="line-through">${{ totalRegularPrice.toFixed(2) }}</p>
+          <p class="text-alizarin-crimson-700">-{{ discountPercentage }}%</p>
+        </div>
+      </div>
+      <div v-else>
+        <div class="font-bold">${{ totalRegularPrice.toFixed(2) }}</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/gql/queries/getProduct.ts
+++ b/app/gql/queries/getProduct.ts
@@ -20,12 +20,12 @@ export const getProductQuery = gql`
             sourceUrl(size: LARGE)
           }
         }
-        allPaStyle {
+        allPaColor {
           nodes {
             name
           }
         }
-        allPaColor {
+        allPaStyle {
           nodes {
             name
           }
@@ -67,7 +67,7 @@ export const getProductQuery = gql`
               name
               regularPrice
               salePrice
-              allPaColor {
+              allPaStyle {
                 nodes {
                   name
                 }

--- a/app/gql/queries/getProduct.ts
+++ b/app/gql/queries/getProduct.ts
@@ -20,12 +20,12 @@ export const getProductQuery = gql`
             sourceUrl(size: LARGE)
           }
         }
-        allPaColor {
+        allPaStyle {
           nodes {
             name
           }
         }
-        allPaStyle {
+        allPaColor {
           nodes {
             name
           }
@@ -67,7 +67,7 @@ export const getProductQuery = gql`
               name
               regularPrice
               salePrice
-              allPaStyle {
+              allPaColor {
                 nodes {
                   name
                 }

--- a/app/pages/favorites.vue
+++ b/app/pages/favorites.vue
@@ -41,7 +41,7 @@ useSeoMeta({
           <div class="grid gap-0.5 text-white">
             <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" variant="card" />
             <div class="font-bold">{{ product.name }}</div>
-            <div class="text-sm font-medium">{{ product.allPaStyle?.nodes[0]?.name }}</div>
+            <div class="text-sm font-medium">{{ product.allPaStyle.nodes[0].name }}</div>
           </div>
         </NuxtLink>
       </div>

--- a/app/pages/favorites.vue
+++ b/app/pages/favorites.vue
@@ -39,12 +39,9 @@ useSeoMeta({
           class="absolute inset-0 bg-gradient-to-t from-black/50 hover:from-black/60 flex items-end p-5"
           :to="localePath(`/product/${product.slug}-${product.sku.split('-')[0]}`)">
           <div class="grid gap-0.5 text-white">
-            <div class="flex gap-2 text-sm">
-              <span v-html="product.salePrice"></span>
-              <span class="line-through text-white/50" v-html="product.regularPrice"></span>
-            </div>
+            <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" variant="card" />
             <div class="font-bold">{{ product.name }}</div>
-            <div class="text-sm font-medium">{{ product.allPaStyle.nodes[0].name }}</div>
+            <div class="text-sm font-medium">{{ product.allPaStyle?.nodes[0]?.name }}</div>
           </div>
         </NuxtLink>
       </div>

--- a/app/pages/product/[id].vue
+++ b/app/pages/product/[id].vue
@@ -51,13 +51,6 @@ watchEffect(() => {
   }
 });
 
-const calculateDiscountPercentage = computed(() => {
-  if (!product.value.salePrice || !product.value.regularPrice) return 0;
-  const salePriceValue = parseFloat(product.value.salePrice.replace(/[^0-9]/g, ''));
-  const regularPriceValue = parseFloat(product.value.regularPrice.replace(/[^0-9]/g, ''));
-  return Math.round(((salePriceValue - regularPriceValue) / regularPriceValue) * 100);
-});
-
 const { handleAddToCart, addToCartButtonStatus } = useCart();
 </script>
 
@@ -110,19 +103,8 @@ const { handleAddToCart, addToCartButtonStatus } = useCart();
         <div class="flex-col flex gap-4 lg:max-h-[530px] xl:max-h-[600px] overflow-hidden">
           <div class="p-3 lg:pb-4 lg:p-0 border-b border-[#efefef] dark:border-[#262626]">
             <h1 class="text-2xl font-semibold mb-1">{{ product.name }}</h1>
-            <div class="flex justify-between flex-row items-baseline">
-              <div class="flex flex-row items-baseline">
-                <p class="text-xl font-bold text-alizarin-crimson-700" v-html="product.salePrice"></p>
-                <p class="text-sm ml-2">{{ $t('product.vat_included') }}</p>
-              </div>
-            </div>
-            <div class="flex-wrap items-baseline flex-row flex">
-              <p class="text-sm">{{ $t('product.originally') }}:</p>
-              <p class="text-sm ml-1 line-through" v-html="product.regularPrice"></p>
-              <p class="text-sm ml-1 text-alizarin-crimson-700">{{ calculateDiscountPercentage }}%</p>
-            </div>
+            <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" />
           </div>
-
           <div class="flex gap-2 px-3 lg:px-0" v-for="(variation, i) in product.productTypes?.nodes" :key="i">
             <div v-for="(vars, i) in variation.products.nodes" :key="i">
               <NuxtLink

--- a/app/pages/product/[id].vue
+++ b/app/pages/product/[id].vue
@@ -8,6 +8,7 @@ const localePath = useLocalePath();
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
+import ProductPrice from "~/components/ProductPrice.vue";
 
 const thumbsSwiper = ref(null);
 const setThumbsSwiper = swiper => {
@@ -49,13 +50,6 @@ watchEffect(() => {
     const variationInStock = sortedVariations.value.find(variation => variation.stockStatus === 'IN_STOCK');
     selectedVariation.value = variationInStock ? variationInStock : null;
   }
-});
-
-const calculateDiscountPercentage = computed(() => {
-  if (!product.value.salePrice || !product.value.regularPrice) return 0;
-  const salePriceValue = parseFloat(product.value.salePrice.replace(/[^0-9]/g, ''));
-  const regularPriceValue = parseFloat(product.value.regularPrice.replace(/[^0-9]/g, ''));
-  return Math.round(((salePriceValue - regularPriceValue) / regularPriceValue) * 100);
 });
 
 const { name } = useAppConfig();
@@ -159,17 +153,7 @@ const { handleAddToCart, addToCartButtonStatus } = useCart();
         <div class="flex-col flex gap-4 lg:max-h-[530px] xl:max-h-[600px] overflow-hidden">
           <div class="p-3 lg:pb-4 lg:p-0 border-b border-[#efefef] dark:border-[#262626]">
             <h1 class="text-2xl font-semibold mb-1">{{ product.name }}</h1>
-            <div class="flex justify-between flex-row items-baseline">
-              <div class="flex flex-row items-baseline">
-                <p class="text-xl font-bold text-alizarin-crimson-700" v-html="product.salePrice"></p>
-                <p class="text-sm ml-2">{{ $t('product.vat_included') }}</p>
-              </div>
-            </div>
-            <div class="flex-wrap items-baseline flex-row flex">
-              <p class="text-sm">{{ $t('product.originally') }}:</p>
-              <p class="text-sm ml-1 line-through" v-html="product.regularPrice"></p>
-              <p class="text-sm ml-1 text-alizarin-crimson-700">{{ calculateDiscountPercentage }}%</p>
-            </div>
+            <ProductPrice :sale-price="product.salePrice" :regular-price="product.regularPrice" />
           </div>
 
           <div class="flex gap-2 px-3 lg:px-0" v-for="(variation, i) in product.productTypes?.nodes" :key="i">
@@ -178,12 +162,12 @@ const { handleAddToCart, addToCartButtonStatus } = useCart();
                 :to="localePath(`/product/${vars.slug}-${product.sku.split('-')[0]}`)"
                 :class="[
                   'flex w-12 rounded-lg border-2 select-varitaion transition-all duration-200 bg-neutral-200 dark:bg-neutral-800',
-                  vars.allPaColor.nodes[0].name === product.allPaColor.nodes[0].name ? 'selected-varitaion' : 'border-[#9b9b9b] dark:border-[#8c8c8c]',
+                  vars.allPaStyle?.nodes[0]?.name === product.allPaStyle.nodes[0].name ? 'selected-varitaion' : 'border-[#9b9b9b] dark:border-[#8c8c8c]',
                 ]">
                 <NuxtImg
-                  :alt="vars.allPaColor.nodes[0].name"
+                  :alt="vars.allPaColor?.nodes[0]?.name"
                   :src="vars.image.sourceUrl"
-                  :title="vars.allPaColor.nodes[0].name"
+                  :title="vars.allPaColor?.nodes[0]?.name"
                   class="rounded-md border-2 border-white dark:border-black" />
               </NuxtLink>
             </div>


### PR DESCRIPTION
Resolves #241

This PR addresses the inconsistent price display logic by creating a single, reusable `<Price>` component. The original code duplicated logic, showed incorrect sale formats, and had a bug in the checkout total calculation. This new component fixes these issues.

I've consolidated all price display styles into this single component, using variants to keep the calculation logic centralized. I'm open to feedback on this approach.